### PR TITLE
Reverted back to copy commands for mac OS X instead of QMAKE_BUNDLE_DATA

### DIFF
--- a/library_deployment.pri
+++ b/library_deployment.pri
@@ -15,10 +15,8 @@ ios {
     # undocumented Qmake property used to autogenerate Q_IMPORT_PLUGIN
     QMLPATHS += $$_PRO_FILE_PWD_/../../src/imports
 } macx {
-    simvis_lib.files = $$OUT_PWD/../../dist/
-    simvis_lib.path = Contents/MacOS
-    QMAKE_BUNDLE_DATA += simvis_lib
-    copy_lib.commands += install_name_tool -change lib$${LIB_TARGET}.dylib @executable_path/$${LIB_NAME}/lib$${LIB_TARGET}.dylib $$OUT_PWD/$${TARGET}.app/Contents/MacOS/$${TARGET}
+    copy_lib.commands = $(COPY_DIR) $$OUT_PWD/../../dist/$${LIB_NAME} $$OUT_PWD/$${TARGET}.app/Contents/MacOS
+    copy_lib.commands += && install_name_tool -change lib$${LIB_TARGET}.dylib @executable_path/$${LIB_NAME}/lib$${LIB_TARGET}.dylib $$OUT_PWD/$${TARGET}.app/Contents/MacOS/$${TARGET}
 } unix:!macx {
     copy_lib.commands = $(COPY_DIR) $$OUT_PWD/../../dist/$${LIB_NAME} $$OUT_PWD
 }


### PR DESCRIPTION
Should (hopefully) fix #14 
